### PR TITLE
fix: esbuild doesn't transpile nested source files

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -184,7 +184,7 @@
           "spawn": "eslint"
         },
         {
-          "exec": "vitest run --coverage --passWithNoTests"
+          "exec": "vitest run --coverage --passWithNoTests --dir src"
         }
       ]
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -81,10 +81,10 @@
           "exec": "tsc --declaration --emitDeclarationOnly"
         },
         {
-          "exec": "esbuild src/*.ts src/**/*.ts --outdir=lib --format=esm --minify --platform=node --sourcemap --target=es2020"
+          "exec": "esbuild $(find src -name '*.ts') --outdir=lib --format=esm --minify --platform=node --sourcemap --target=es2020"
         },
         {
-          "exec": "esbuild src/*.ts src/**/*.ts --outdir=lib --format=cjs --minify --platform=node --sourcemap --target=node14 --out-extension:.js=.cjs"
+          "exec": "esbuild $(find src -name '*.ts') --outdir=lib --format=cjs --minify --platform=node --sourcemap --target=node14 --out-extension:.js=.cjs"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -116,7 +116,7 @@ project.addGitIgnore("*.d.ts");
 
 // Tests.
 project.addDevDeps("vitest", "c8");
-project.testTask.exec("vitest run --coverage --passWithNoTests");
+project.testTask.exec("vitest run --coverage --passWithNoTests --dir src");
 project.addPackageIgnore("coverage/");
 
 // Lint.

--- a/.projenrc.typescript.ts
+++ b/.projenrc.typescript.ts
@@ -63,10 +63,10 @@ export class TypeScript extends Component {
     nodeProject.compileTask.reset();
     nodeProject.compileTask.exec(`tsc --declaration --emitDeclarationOnly`);
     nodeProject.compileTask.exec(
-      `esbuild src/*.ts src/**/*.ts --outdir=${libdir} --format=esm --minify --platform=node --sourcemap --target=es2020`,
+      `esbuild $(find src -name '*.ts') --outdir=${libdir} --format=esm --minify --platform=node --sourcemap --target=es2020`,
     );
     nodeProject.compileTask.exec(
-      `esbuild src/*.ts src/**/*.ts --outdir=${libdir} --format=cjs --minify --platform=node --sourcemap --target=node14 --out-extension:.js=.cjs`,
+      `esbuild $(find src -name '*.ts') --outdir=${libdir} --format=cjs --minify --platform=node --sourcemap --target=node14 --out-extension:.js=.cjs`,
     );
     nodeProject.postCompileTask.exec(`mv ${libdir}/* .`);
 


### PR DESCRIPTION
The recursive glob pattern `src/**/*.ts` doesn't work as expected when used in a terminal such as `/bin/sh`.
A replacement for it is to use `find src -name '*.ts'`.
